### PR TITLE
[FEATURE] Adds macOS support to downloaded aria2-download-Shellscript

### DIFF
--- a/download.php
+++ b/download.php
@@ -432,6 +432,7 @@ INFO;
     <p><b><?php echo $s['aria2NoticeText2']; ?></b><br/>
     - Windows: <code>aria2_download_windows.cmd</code><br/>
     - Linux: <code>aria2_download_linux.sh</code><br/>
+    - macOS: <code>aria2_download_macos.sh</code><br/>
     </p>
 
     <p>

--- a/shared/get.php
+++ b/shared/get.php
@@ -317,8 +317,10 @@ CONFIG;
     if($open === TRUE) {
         $zip->addFromString('aria2_download_windows.cmd', $cmdScript);
         $zip->addFromString('aria2_download_linux.sh', $shellScript);
+        $zip->addFromString('aria2_download_macos.sh', $shellScript);
         $zip->addFromString('ConvertConfig.ini', $convertConfig);
         $zip->addFromString('files/convert_config_linux', $convertConfigLinux);
+        $zip->addFromString('files/convert_config_macos', $convertConfigLinux);
         $zip->addFile($currDir.'/autodl_files/aria2c.exe', 'files/aria2c.exe');
         $zip->addFile($currDir.'/autodl_files/convert.sh', 'files/convert.sh');
         $zip->addFile($currDir.'/autodl_files/convert_ve_plugin', 'files/convert_ve_plugin');
@@ -488,6 +490,7 @@ SCRIPT;
     if($open === TRUE) {
         $zip->addFromString('aria2_download_windows.cmd', $cmdScript);
         $zip->addFromString('aria2_download_linux.sh', $shellScript);
+        $zip->addFromString('aria2_download_macos.sh', $shellScript);
         $zip->addFile($currDir.'/autodl_files/aria2c.exe', 'files/aria2c.exe');
         $zip->close();
     } else {

--- a/shared/get.php
+++ b/shared/get.php
@@ -182,17 +182,27 @@ if ! which aria2c >/dev/null \\
 || ! which cabextract >/dev/null \\
 || ! which wimlib-imagex >/dev/null \\
 || ! which chntpw >/dev/null \\
-|| ! which genisoimage >/dev/null; then
+|| ! which genisoimage >/dev/null \\
+&& ! which mkisofs >/dev/null; then
   echo "One of required applications is not installed."
   echo "The following applications need to be installed to use this script:"
   echo " - aria2c"
   echo " - cabextract"
   echo " - wimlib-imagex"
   echo " - chntpw"
-  echo " - genisoimage"
+  echo " - genisoimage or mkisofs"
   echo ""
-  echo "If you use Debian or Ubuntu you can install these using:"
-  echo "sudo apt-get install aria2 cabextract wimtools chntpw genisoimage"
+  if [ `uname` == "Linux" ]; then
+    # Linux
+    echo "If you use Debian or Ubuntu you can install these using:"
+    echo "sudo apt-get install aria2 cabextract wimtools chntpw genisoimage"
+  elif [ `uname` == "Darwin" ]; then
+    # macOS
+    echo "macOS requires Homebrew (https://brew.sh) to install the prerequisite software."
+    echo "If you use Homebrew, you can install these using:"
+    echo "brew tap sidneys/homebrew"
+    echo "brew install aria2 cabextract wimlib cdrtools sidneys/homebrew/chntpw"
+  fi
   exit 1
 fi
 

--- a/shared/langs/ar-sa.php
+++ b/shared/langs/ar-sa.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'سيتم إنشاء وتحميل ملف مضغوط ي�
 $s['aria2NoticeText2'] = ':لبدء عملية التنزيل استخرج الملف المضغوط ثم شغل السكريبت المناسب حسب نظامك';
 $s['aria2NoticeText3'] = '%s :هو برنامج مفتوح المصدر، يمكنك إيجاده هنا Aria2'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = '%s :سكريبت التحويل (نسخة ويندوز) تم إنشاؤه بواسطة'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = '%s :سكريبت التحويل (نسخة لينكس) مفتوح المصدر، يمكنك إيجاده هنا'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = '%s :سكريبت التحويل (نسخة لينكس , نسخة ماك) مفتوح المصدر، يمكنك إيجاده هنا'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'تصفح الملفات - %s'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'لإعادة تسمية الملفات بعد التنزيل، يمكنك إنشاء وتحميل سكريبت العملية تلقائياً';
 $s['fileRenamingScriptGenW'] = 'إنشاء سكريبت إعادة التسمية - ويندوز';
-$s['fileRenamingScriptGenL'] = 'إنشاء سكريبت إعادة التسمية - لينكس';
+$s['fileRenamingScriptGenL'] = 'إنشاء إعادة تسمية البرنامج النصي - لينكس ، ماك';
 $s['searchForFiles'] = '...البحث في الملفات';
 $s['weFoundFiles'] = 'عدد الملفات: <b>%d</b>'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/de-de.php
+++ b/shared/langs/de-de.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'Die Optionen <i>Download mit aria2</i> erstellt ein Ar
 $s['aria2NoticeText2'] = 'Um den Download-Prozess zu starten, verwenden Sie das Skript für Ihre Plattform:';
 $s['aria2NoticeText3'] = 'Aria2 ist ein Open-Source-Projekt. Sie finden es hier: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'Das UUP Konvertierungsskript (Windows-Version) wurde erstellt von %s.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'Das UUP-Konvertierungsskript (Linux-Version) ist Open Source. Sie finden es hier: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'Das UUP-Konvertierungsskript (Linux-Version, macOS-Version) ist Open Source. Sie finden es hier: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Dateien finden in %s'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Wenn Sie Dateien, die Sie von dieser Seite herunterladen, schnell umbenennen möchten, können Sie ein Umbenennungsskript generieren, das dies automatisch für Sie erledigt.';
 $s['fileRenamingScriptGenW'] = 'Umbenennungsskript generieren (Windows)';
-$s['fileRenamingScriptGenL'] = 'Umbenennungsskript generieren (Linux)';
+$s['fileRenamingScriptGenL'] = 'Umbenennungsskript generieren (Linux, macOS)';
 $s['searchForFiles'] = 'Nach Dateien suchen...';
 $s['weFoundFiles'] = 'Wir haben <b>%d</b> Dateien für Ihre Anfrage gefunden.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/en-us.php
+++ b/shared/langs/en-us.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'Download using aria2 options create an archive which n
 $s['aria2NoticeText2'] = 'To start the download process use a script for your platform:';
 $s['aria2NoticeText3'] = 'Aria2 is an open source project. You can find it here: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'The UUP Conversion script (Windows version) has been created by %s.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'The UUP Conversion script (Linux version) is open source. You can find it here: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'The UUP Conversion script (Linux version, macOS version) is open source. You can find it here: %s.'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Find files in %s'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'If you want to quickly rename files downloaded from this page, you can generate a renaming script, which will automatically do this for you.';
 $s['fileRenamingScriptGenW'] = 'Generate renaming script (Windows)';
-$s['fileRenamingScriptGenL'] = 'Generate renaming script (Linux)';
+$s['fileRenamingScriptGenL'] = 'Generate renaming script (Linux, macOS)';
 $s['searchForFiles'] = 'Search for files...';
 $s['weFoundFiles'] = 'We have found <b>%d</b> files for your query.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/es-ar.php
+++ b/shared/langs/es-ar.php
@@ -162,13 +162,13 @@ $s['aria2NoticeText1'] = 'Al descargar usando las opciones aria2 se crea un cont
 $s['aria2NoticeText2'] = 'Para comenzar el proceso de descarga, usa un script para tu plataforma:';
 $s['aria2NoticeText3'] = 'Aria2 es un proyecto de código abierto. Puedes encontrarlo aquí: %s.'; //Aria2 es un proyecto de código abierto. Puedes encontrarlo aquí: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'El script de conversión de la UUP (versión Windows) fue creado por %s.'; //El script de conversión de la UUP (versión Windows) fue creado por abbodi1406.
-$s['aria2NoticeText5'] = 'El script de conversión de la UUP (versión Linux) es de código abierto. Puedes encontrarlo aquí: %s.'; //El script de conversión de la UUP (versión Linux) es de código abierto. Puedes encontrarlo aquí: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'El script de conversión de la UUP (versión Linux, version macOS) es de código abierto. Puedes encontrarlo aquí: %s.'; //El script de conversión de la UUP (versión Linux, version macOS) es de código abierto. Puedes encontrarlo aquí: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Buscar archivos en %s'; //Buscar archivos en Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Si quieres renombrar rápidamente los archivos descargados de esta página, puedes generar un script que los renombrará automáticamente por ti.';
 $s['fileRenamingScriptGenW'] = 'Generar un script para renombrar (Windows)';
-$s['fileRenamingScriptGenL'] = 'Generar un script para renombrar (Linux)';
+$s['fileRenamingScriptGenL'] = 'Generar un script para renombrar (Linux, macOS)';
 $s['searchForFiles'] = 'Buscar archivos...';
 $s['weFoundFiles'] = 'Hemos encontrado <b>%d</b> archivos para tu consulta.'; //Hemos encontrado <b>692</b> archivos para tu consulta.
 

--- a/shared/langs/fr-fr.php
+++ b/shared/langs/fr-fr.php
@@ -152,13 +152,13 @@ $s['aria2NoticeText1'] = 'Le téléchargement à l\'aide des options aria2 crée
 $s['aria2NoticeText2'] = 'Pour lancer le processus de téléchargement, utilisez un script pour votre plate-forme:';
 $s['aria2NoticeText3'] = 'AAria2 est un projet open source. Vous pouvez le trouver ici: % s.';//Aria2 est un projet open source. Vous pouvez le trouver ici: https://aria2.github.io/..
 $s['aria2NoticeText4'] = 'Le script UUP Conbuild (génération Windows) a été créé par %s.'; //Le script Conbuild UUP (version Windows) a été créé par abbodi1406.
-$s['aria2NoticeText5'] = 'Le script UUP Conbuild (version Linux) est à code source ouvert. Vous pouvez le trouver ici: %s.'; //Le script UUP Conbuild (version Linux) est open source. Vous pouvez le trouver ici: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'Le script UUP Conbuild (version Linux, version macOS) est à code source ouvert. Vous pouvez le trouver ici: %s.'; //Le script UUP Conbuild (version Linux, version macOS) est open source. Vous pouvez le trouver ici: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Trouver les fichiers dans %s'; //Trouver des fichiers dans Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Si vous souhaitez renommer rapidement des fichiers téléchargés à partir de cette page, vous pouvez générer un script de changement de nom, qui le fera automatiquement à votre place.';
 $s['fileRenamingScriptGenW'] = 'Générer un script de changement de nom (Windows)';
-$s['fileRenamingScriptGenL'] = 'Générer un script de changement de nom (Linux)';
+$s['fileRenamingScriptGenL'] = 'Générer un script de changement de nom (Linux, macOS)';
 $s['searchForFiles'] = 'Rechercher des fichiers...';
 $s['weFoundFiles'] = 'Nous avons trouvé <b>%d</b> ichiers pour votre requête.'; //Nous avons trouvé <b>692</b> fichiers pour votre requête.
 

--- a/shared/langs/hu-hu.php
+++ b/shared/langs/hu-hu.php
@@ -158,16 +158,16 @@ $s['sha1File'] = 'SHA-1 ellenőrző összeg fájl';
 $s['sha1FileDesc'] = 'A fájl segítségével gyorsan ellenőrizheti, hogy a fájlok megfelelően lettek-e letöltve.';
 $s['aria2NoticeTitle'] = 'Töltse le az aria2 segítségével';
 $s['aria2NoticeText1'] = 'Letöltés az aria2 opciókkal létrehoz egy archívumot, amelyet le kell tölteni. A letöltött archívum tartalmazza a kiválasztott feladat végrehajtásához szükséges fájlokat.';
-$s['aria2NoticeText2'] = 'A letöltési folyamat elindításához használja parancsfájlt a saját platformján (Windows, Linux):';
+$s['aria2NoticeText2'] = 'A letöltési folyamat elindításához használja parancsfájlt a saját platformján (Windows, Linux, macOS):';
 $s['aria2NoticeText3'] = 'Az Aria2 nyílt forráskódú projekt. Itt található: %s.'; //Az Aria2 egy nyílt forráskódú projekt. Itt található: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'Az UUP konverziós szkriptet (Windows verzió) %s hozta létre.'; //Az UUP konverziós szkriptet (Windows verzió) abbodi1406 hozta létre.
-$s['aria2NoticeText5'] = 'Az UUP konverziós szkript (Linux verzió) nyílt forrású. Itt található: %s.'; //Az UUP konverziós szkript (Linux verzió) nyílt forrású. Itt található: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'Az UUP konverziós szkript (Linux verzió, macOS verzió) nyílt forrású. Itt található: %s.'; //Az UUP konverziós szkript (Linux verzió, macOS verzió) nyílt forrású. Itt található: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Fájlok keresése a(z) %s fájlban'; //Fájlok keresése a Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64 fájlban
 $s['fileRenamingScriptDescFindFiles'] = 'Ha gyorsan át szeretné nevezni az ezen az oldalon letöltött fájlokat, létrehozhat egy átnevező szkriptet, amely automatikusan ezt megteszi az Ön számára.';
 $s['fileRenamingScriptGenW'] = 'Átnevező szkript létrehozása (Windows)';
-$s['fileRenamingScriptGenL'] = 'Átnevező szkript létrehozása (Linux)';
+$s['fileRenamingScriptGenL'] = 'Átnevező szkript létrehozása (Linux, macOS)';
 $s['searchForFiles'] = 'Fájlok keresése...';
 $s['weFoundFiles'] = '<b>%d</b> fájlokat találtunk a lekérdezéshez.'; //<b>692</b> fájlokat találtunk a lekérdezéséhez.
 

--- a/shared/langs/it-it.php
+++ b/shared/langs/it-it.php
@@ -163,13 +163,13 @@ $s['aria2NoticeText1'] = 'Verrà creato un archivio per scaricare con aria2. L�
 $s['aria2NoticeText2'] = 'Per avviare il processo di download, utilizzare uno script per la propria piattaforma:';
 $s['aria2NoticeText3'] = 'Aria2 è un progetto open source. Lo puoi trovare qui: %s.'; //Aria2 è un progetto open source. Lo puoi trovare qui: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'Lo script di conversione UUP (versione Windows) è stato creato da %s.'; //Lo script di conversione UUP (versione Windows) è stato creato da abbodi1406.
-$s['aria2NoticeText5'] = 'Lo script di conversione UUP (versione Linux) è open source. Lo puoi trovare qui: %s.'; //Lo script di conversione UUP (versione Linux) è open source. Lo puoi trovare qui: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'Lo script di conversione UUP (versione Linux, versione macOS) è open source. Lo puoi trovare qui: %s.'; //Lo script di conversione UUP (versione Linux, versione macOS) è open source. Lo puoi trovare qui: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Trova file in %s'; //Trova file in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Se si desidera rinominare rapidamente i file scaricati da questa pagina, è possibile generare uno script di ridenominazione, che lo farà automaticamente.';
 $s['fileRenamingScriptGenW'] = 'Genera script di rinomina (Windows)';
-$s['fileRenamingScriptGenL'] = 'Genera script di rinomina (Linux)';
+$s['fileRenamingScriptGenL'] = 'Genera script di rinomina (Linux, macOS)';
 $s['searchForFiles'] = 'Cerca i file...';
 $s['weFoundFiles'] = 'Sono stati trovati <b>%d</b> file per la tua richiesta.'; //Sono stati trovati <b>692</b> file per la tua richiesta.
 

--- a/shared/langs/ko-kr.php
+++ b/shared/langs/ko-kr.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'aria2 옵션을 사용하여 다운로드하면 다운
 $s['aria2NoticeText2'] = '다운로드 프로세스를 시작하려면 플랫폼에 맞는 스크립트를 사용하십시오.';
 $s['aria2NoticeText3'] = 'Aria2는 오픈 소스 프로젝트입니다. 여기에서 찾을 수 있습니다 : %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'UUP 변환 스크립트 (Windows 버전)가 %s에 의해 생성되었습니다.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'UUP 변환 스크립트 (Linux 버전)는 오픈 소스입니다. 여기에서 찾을 수 있습니다 : %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'UUP 변환 스크립트 (Linux 버전, macOS 버전) 는 오픈 소스입니다. 여기에서 찾을 수 있습니다 : %s.'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = '%s에있는 파일 찾기'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = '이 페이지에서 다운로드 한 파일의 이름을 바꾸려면 이름 바꾸기 스크립트를 생성하면 자동으로 이 작업이 수행됩니다.';
 $s['fileRenamingScriptGenW'] = '이름 바꾸기 스크립트 생성 (Windows)';
-$s['fileRenamingScriptGenL'] = '이름 바꾸기 스크립트 생성 (Linux)';
+$s['fileRenamingScriptGenL'] = '이름 바꾸기 스크립트 생성 (Linux, macOS)';
 $s['searchForFiles'] = '파일 검색...';
 $s['weFoundFiles'] = '귀하의 검색어에 대해 <b>%d</ b> 파일을 발견했습니다.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/nl-nl.php
+++ b/shared/langs/nl-nl.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'Downloaden mbv aria2 creeert een zip bestand dat moet 
 $s['aria2NoticeText2'] = 'Kies het voor jouw platform geschikte script om het download process te starten:';
 $s['aria2NoticeText3'] = 'Aria2 is een open source project. Je kunt het hier vinden: %s.'; //Aria2 is een open source project. Je kunt het hier vinden: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'Het UUP Conversie script (Windows versie) is gemaakt door %s.'; //UUP Conversie script (Windows versie) is gemaakt door abbodi1406.
-$s['aria2NoticeText5'] = 'Het UUP Conversie script (Linux versie) is open source. Je kunt het hier vinden: %s.'; //UUP Conversie script (Linux versie) is open source. Je kunt het hier vinden: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'Het UUP Conversie script (Linux versie, macOS versie) is open source. Je kunt het hier vinden: %s.'; //UUP Conversie script (Linux versie, macOS versie) is open source. Je kunt het hier vinden: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Vind bestanden voor %s'; //Vind bestanden voor Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Wanneer U de gedownloade bestanden van deze pagina snel wilt hernoemen, kunt U een hernoemings script maken, die dit automatisch voor U doet.';
 $s['fileRenamingScriptGenW'] = 'Maak hernoemings script (Windows)';
-$s['fileRenamingScriptGenL'] = 'Maak hernoemings script (Linux)';
+$s['fileRenamingScriptGenL'] = 'Maak hernoemings script (Linux, macOS)';
 $s['searchForFiles'] = 'Zoek naar bestanden...';
 $s['weFoundFiles'] = 'We hebben <b>%d</b> bestanden gevonden.'; //We hebben <b>692</b> bestanden gevonden.
 

--- a/shared/langs/pl-pl.php
+++ b/shared/langs/pl-pl.php
@@ -143,7 +143,7 @@ $s['aria2NoticeText1'] = 'Opcje <i>Pobierz przy użyciu programu aria2</i> tworz
 $s['aria2NoticeText2'] = 'Aby rozpocząć proces użyj skryptu przeznaczonego dla Twojej platformy:';
 $s['aria2NoticeText3'] = 'Aria2 jest projektem otwartoźródłowym. Możesz znaleźć go tutaj: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'Skrypt konwersji UUP (wersja dla Windows) został stworzony przez %s.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'Skrypt konwersji UUP (wersja dla Linux) jest otwartoźródłowy. Możesz znaleźć go tutaj: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'Skrypt konwersji UUP (wersja dla Linux, wersja dla macOS) jest otwartoźródłowy. Możesz znaleźć go tutaj: %s.'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 $s['selectDownloadOptions'] = 'Wybierz opcje pobierania';
 $s['selectDownloadOptionsSub'] = 'Skonfiguruj w jaki sposob chcesz pobrać swój wybór';
 $s['downloadMethod'] = 'Metoda pobierania';
@@ -167,7 +167,7 @@ $s['sha1FileDesc'] = 'Możesz użyć tego pliku w celu szybkiej weryfikacji czy 
 $s['findFilesIn'] = 'Szukaj plików w %s'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'W przypadku chęci szybkiej zmiany nazwy plików pobranych z tej strony, możesz wygenerować skrypt zmieniający nazwy, który wykona tę operację za Ciebie.';
 $s['fileRenamingScriptGenW'] = 'Wygeneruj skrypt zmiany nazw (wersja dla Windows)';
-$s['fileRenamingScriptGenL'] = 'Wygeneruj skrypt zmiany nazw (wersja dla Linux)';
+$s['fileRenamingScriptGenL'] = 'Wygeneruj skrypt zmiany nazw (wersja dla Linux, wersja dla macOS)';
 $s['searchForFiles'] = 'Szukaj plików...';
 $s['weFoundFiles'] = 'Znaleźliśmy <b>%d</b> plików dla Twojego zapytania.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/pt-br.php
+++ b/shared/langs/pt-br.php
@@ -162,13 +162,13 @@ $s['aria2NoticeText1'] = 'O download usando as opções aria2 cria um arquivo qu
 $s['aria2NoticeText2'] = 'Para iniciar o processo de download, use um script para sua plataforma:';
 $s['aria2NoticeText3'] = 'Aria2 é um projeto de código aberto. Você pode encontrá-lo aqui: %s.'; //Aria2 é um projeto de código aberto. Você pode encontrá-lo aqui: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'O script de conversão UUP (versão Windows) foi criado por %s.'; //O script de conversão UUP (versão Windows) foi criado por abbodi1406.
-$s['aria2NoticeText5'] = 'O script de conversão UUP (versão Linux) é de código aberto. Você pode encontrá-lo aqui: %s.'; //O script de conversão UUP (versão Linux) é de código aberto. Você pode encontrá-lo aqui: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'O script de conversão UUP (versão Linux, versão macOS) é de código aberto. Você pode encontrá-lo aqui: %s.'; //O script de conversão UUP (versão Linux, versão macOS) é de código aberto. Você pode encontrá-lo aqui: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Encontrar arquivos em %s'; //Localizar arquivos no Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Se deseja renomear rapidamente os arquivos baixados desta página, você pode gerar um script de renomeação, que fará isso automaticamente.';
 $s['fileRenamingScriptGenW'] = 'Gerar script de renomeação (Windows)';
-$s['fileRenamingScriptGenL'] = 'Gerar script de renomeação (Linux)';
+$s['fileRenamingScriptGenL'] = 'Gerar script de renomeação (Linux, macOS)';
 $s['searchForFiles'] = 'Procurar arquivos...';
 $s['weFoundFiles'] = 'Encontramos <b>%d</b> arquivos para sua consulta.';//Encontramos <b>692</b> arquivos para sua consulta.
 

--- a/shared/langs/pt-pt.php
+++ b/shared/langs/pt-pt.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'Fazer o download usando as opções aria2 cria um fich
 $s['aria2NoticeText2'] = 'Para iniciar o processo de download, use um script para a sua plataforma:';
 $s['aria2NoticeText3'] = 'Aria2 é um projeto de código aberto. Pode encontrá-lo aqui: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'O script de conversão UUP (versão Windows) foi criado por %s.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'O script de conversão UUP (versão Linux) é de código aberto. Pode encontrá-lo aqui: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'O script de conversão UUP (versão Linux, versão macOS) é de código aberto. Pode encontrá-lo aqui: %s.'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = 'Encontre ficheiros em %s'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Se quiser renomear rapidamente os ficheiros transferidos desta página, pode gerar um script de renomeação, que fará isso automaticamente.';
 $s['fileRenamingScriptGenW'] = 'Gerar script de renomeação (Windows)';
-$s['fileRenamingScriptGenL'] = 'Gerar script de renomeação (Linux)';
+$s['fileRenamingScriptGenL'] = 'Gerar script de renomeação (Linux, macOS)';
 $s['searchForFiles'] = 'Procurar ficheiros ...';
 $s['weFoundFiles'] = 'Encontrámos ficheiros <b>%d</b> para a sua consulta.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/qps-ploc.php
+++ b/shared/langs/qps-ploc.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = '[5d83] Ḓǿẇƞŀǿȧḓ ŭşīƞɠ ȧřīȧ2 ǿƥŧ
 $s['aria2NoticeText2'] = '[f3a9] Ŧǿ şŧȧřŧ ŧħḗ ḓǿẇƞŀǿȧḓ ƥřǿƈḗşş ŭşḗ ȧ şƈřīƥŧ ƒǿř ẏǿŭř ƥŀȧŧƒǿřḿ:';
 $s['aria2NoticeText3'] = '[ad6a] Ȧřīȧ2 īş ȧƞ ǿƥḗƞ şǿŭřƈḗ ƥřǿĵḗƈŧ. Ẏǿŭ ƈȧƞ ƒīƞḓ īŧ ħḗřḗ: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = '[d701] Ŧħḗ ŬŬƤ Ƈǿƞṽḗřşīǿƞ şƈřīƥŧ (Ẇīƞḓǿẇş ṽḗřşīǿƞ) ħȧş ƀḗḗƞ ƈřḗȧŧḗḓ ƀẏ %s.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = '[1021] Ŧħḗ ŬŬƤ Ƈǿƞṽḗřşīǿƞ şƈřīƥŧ (Ŀīƞŭẋ ṽḗřşīǿƞ) īş ǿƥḗƞ şǿŭřƈḗ. Ẏǿŭ ƈȧƞ ƒīƞḓ īŧ ħḗřḗ: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = '[1021] Ŧħḗ ŬŬƤ Ƈǿƞṽḗřşīǿƞ şƈřīƥŧ (Ŀīƞŭẋ ṽḗřşīǿƞ, ḿȧƈǾŞ ṽḗřşīǿƞ) īş ǿƥḗƞ şǿŭřƈḗ. Ẏǿŭ ƈȧƞ ƒīƞḓ īŧ ħḗřḗ: %s.'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = '[0ec3] Ƒīƞḓ ƒīŀḗş īƞ %s'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = '[ce12] Īƒ ẏǿŭ ẇȧƞŧ ŧǿ ɋŭīƈķŀẏ řḗƞȧḿḗ ƒīŀḗş ḓǿẇƞŀǿȧḓḗḓ ƒřǿḿ ŧħīş ƥȧɠḗ, ẏǿŭ ƈȧƞ ɠḗƞḗřȧŧḗ ȧ řḗƞȧḿīƞɠ şƈřīƥŧ, ẇħīƈħ ẇīŀŀ ȧŭŧǿḿȧŧīƈȧŀŀẏ ḓǿ ŧħīş ƒǿř ẏǿŭ.';
 $s['fileRenamingScriptGenW'] = '[25c5] Ɠḗƞḗřȧŧḗ řḗƞȧḿīƞɠ şƈřīƥŧ (Ẇīƞḓǿẇş)';
-$s['fileRenamingScriptGenL'] = '[ed2e] Ɠḗƞḗřȧŧḗ řḗƞȧḿīƞɠ şƈřīƥŧ (Ŀīƞŭẋ)';
+$s['fileRenamingScriptGenL'] = '[ed2e] Ɠḗƞḗřȧŧḗ řḗƞȧḿīƞɠ şƈřīƥŧ (Ŀīƞŭẋ, ḿȧƈǾŞ)';
 $s['searchForFiles'] = '[afde] Şḗȧřƈħ ƒǿř ƒīŀḗş...';
 $s['weFoundFiles'] = '[18ae] Ẇḗ ħȧṽḗ ƒǿŭƞḓ <b>%d</b> ƒīŀḗş ƒǿř ẏǿŭř ɋŭḗřẏ.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/tr-tr.php
+++ b/shared/langs/tr-tr.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = 'aria2 Seçeneklerini kullanarak indir, indirilmesi ger
 $s['aria2NoticeText2'] = 'İndirme işlemini başlatmak için platformunuz için bir komut dosyası kullanın:';
 $s['aria2NoticeText3'] = 'aria2 açık kaynaklı bir projedir. Burada bulabilirsiniz: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'UUP Dönüşüm komut dosyası (Windows sürümü) %s tarafından oluşturuldu.'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'UUP Dönüşüm betiği (Linux sürümü) açık kaynak kodludur. Burada bulabilirsiniz: %s.'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'UUP Dönüşüm betiği (Linux sürümü, macOS sürümü) açık kaynak kodludur. Burada bulabilirsiniz: %s.'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = '%s İçindeki dosyaları bul'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = 'Bu sayfadan indirilen dosyaları hızlı bir şekilde yeniden adlandırmak istiyorsanız, bunu sizin için otomatik olarak yapacak bir yeniden adlandırma komut dosyası oluşturabilirsiniz.';
 $s['fileRenamingScriptGenW'] = 'Yeniden adlandırma komut dosyası oluşturma (Windows)';
-$s['fileRenamingScriptGenL'] = 'Yeniden adlandırma komut dosyası oluşturma (Linux)';
+$s['fileRenamingScriptGenL'] = 'Yeniden adlandırma komut dosyası oluşturma (Linux, macOS)';
 $s['searchForFiles'] = 'Dosya ara...';
 $s['weFoundFiles'] = 'Sorgunuz için <b>%d</b> dosya bulundu.'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/zh-cn.php
+++ b/shared/langs/zh-cn.php
@@ -161,13 +161,13 @@ $s['aria2NoticeText1'] = '使用 aria2 选项下载可创建需要下载的存�
 $s['aria2NoticeText2'] = '要开始下载过程，请使用适用于你的平台的脚本：';
 $s['aria2NoticeText3'] = 'Aria2 是一个开源项目，你可以在这里找到它：%s。'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'UUP 转换脚本（Windows 版本）已由 %s 创建。'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'UUP 转换脚本（Linux 版本）是开源的，你可以在这里找到它：%s。'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'UUP 转换脚本（Linux 版本, macOS 版本）是开源的，你可以在这里找到它：%s。'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = '在 %s 中查找文件'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = '如果要快速重命名在此页面下载的文件，可以生成重命名脚本，此脚本将自动为你执行此操作。';
 $s['fileRenamingScriptGenW'] = '生成重命名脚本（Windows）';
-$s['fileRenamingScriptGenL'] = '生成重命名脚本（Linux）';
+$s['fileRenamingScriptGenL'] = '生成重命名脚本（Linux, macOS）';
 $s['searchForFiles'] = '查找文件……';
 $s['weFoundFiles'] = '在你的查询中我们找到了 <b>%d</b> 个文件。'; //We have found <b>692</b> files for your query.
 

--- a/shared/langs/zh-tw.php
+++ b/shared/langs/zh-tw.php
@@ -166,13 +166,13 @@ $s['aria2NoticeText1'] = '[使用 aria2 下載] 選項會建立一個需要下�
 $s['aria2NoticeText2'] = '請使用適用於您的平台的指令碼來開始下載程序:';
 $s['aria2NoticeText3'] = 'Aria2 是個開放原始碼的專案。您可以在這裡找到: %s.'; //Aria2 is an open source project. You can find it here: https://aria2.github.io/.
 $s['aria2NoticeText4'] = 'UUP 轉換指令碼 (Windows 版本) 是由 %s 製作的。'; //UUP Conversion script (Windows version) has been created by abbodi1406.
-$s['aria2NoticeText5'] = 'UUP 轉換指令碼 (Linux 版本) 是開放原始碼的。您可以在這裡找到: %s。'; //UUP Conversion script (Linux version) is open source. You can find it here: https://github.com/uup-dump/converter.
+$s['aria2NoticeText5'] = 'UUP 轉換指令碼 (Linux 版本, macOS 版本) 是開放原始碼的。您可以在這裡找到: %s。'; //UUP Conversion script (Linux version, macOS version) is open source. You can find it here: https://github.com/uup-dump/converter.
 
 //findfiles.php
 $s['findFilesIn'] = '在 %s 尋找檔案'; //Find files in Windows 10 Insider Preview 18890.1000 (rs_prerelease) amd64
 $s['fileRenamingScriptDescFindFiles'] = '如果您想要快速地重新命名下載的檔案，那您可以產生重新命名指令碼來自動幫您重新命名。';
 $s['fileRenamingScriptGenW'] = '產生重新命名指令碼 (Windows)';
-$s['fileRenamingScriptGenL'] = '產生重新命名指令碼 (Linux)';
+$s['fileRenamingScriptGenL'] = '產生重新命名指令碼 (Linux, macOS)';
 $s['searchForFiles'] = '搜尋檔案...';
 $s['weFoundFiles'] = '我們已依您的搜尋內容找到了 <b>%d</b> 個檔案。'; //We have found <b>692</b> files for your query.
 


### PR DESCRIPTION
## ℹ️  Description
These changes extend the documentation section within the `aria2_download` shell script, adding support hints for macOS environments, with full backwards compatibility.  

A pull request adding full macOS support to the uup **converter** [was also added](https://github.com/uup-dump/converter/pull/4).

## 🔧  Implementation
 - package previous Linux-only files also for macOS, using the `_macos` suffix (`aria2_download_macos.sh`, `convert_config_macos`)
 - update help texts inside aria2-downloader-shellscript (`/shared/get.php`)
 - updates all language strings to feature hints regarding macOS support

## 🕹 Testing
Tested on macOS 10.14.6 Mojave

## 📹  Example (macOS 10.14.6 Mojave)

```bash
One of required applications is not installed.
The following applications need to be installed to use this script:
 - aria2c
 - cabextract
 - wimlib-imagex
 - chntpw
 - genisoimage or mkisofs

macOS requires Homebrew (https://brew.sh) to install the prerequisite software.
If you use Homebrew, you can install these using:
brew tap sidneys/homebrew
brew install aria2 cabextract wimlib cdrtools sidneys/homebrew/chntpw
```

