### PR TITLE
Select Edition page improvements

### DIFF
--- a/selectedition.php
+++ b/selectedition.php
@@ -54,6 +54,8 @@ if(!isset($updateInfo['sku'])) {
     $uSku = $updateInfo['sku'];
 }
 
+$hiddenEditions = ['PPIPRO'];
+
 $build = explode('.', $updateInfo['build']);
 $build = @$build[0];
 $disableVE = 0;
@@ -142,29 +144,24 @@ if($updateArch == 'arm64') {
                 <div class="grouped fields">
 <?php
 foreach($editions as $key => $val) {
-if($editionsNum > 1 && $key == 'PPIPRO') {
+    $isHidden = $editionsNum > 1 && in_array($key, $hiddenEditions);
+    $checked = $isHidden ? '' : 'checked';
+    $classHidden = $isHidden ? 'hidden-edition' : '';
+
     echo <<<EOD
-<div class="field">
+<div class="field $classHidden">
     <div class="ui checkbox">
-        <input type="checkbox" name="edition[]" value="$key" class="edition-selection" null>
+        <input type="checkbox" name="edition[]" value="$key" class="edition-selection" $checked>
         <label>$val</label>
     </div>
 </div>
 
 EOD;
-    } else {
-    echo <<<EOD
-<div class="field">
-    <div class="ui checkbox">
-        <input type="checkbox" name="edition[]" value="$key" class="edition-selection" checked>
-        <label>$val</label>
-    </div>
-</div>
-
-EOD;
-    }
 }
 ?>
+                    <button id="show-hidden-editions" type="button" class="ui mini button" style="display: none;">
+                        <?php echo $s['showHiddenEditions']; ?>
+                    </button>
                 </div>
             </div>
 
@@ -281,9 +278,25 @@ function checkEditions() {
     }
 }
 
+function showHiddenEditions() {
+    $('.hidden-edition').show();
+    $('.hidden-edition .edition-selection').prop('disabled', 0);
+    $('#show-hidden-editions').hide();
+}
+
 $('.edition-selection').on('click change', function() {
     checkEditions();
 });
+
+$('#show-hidden-editions').on('click', function() {
+    showHiddenEditions();
+});
+
+if($('.hidden-edition').length > 0) {
+    $('#show-hidden-editions').show();
+    $('.hidden-edition .edition-selection').prop('disabled', 1);
+    $('.hidden-edition').hide();    
+}
 
 checkEditions();
 </script>

--- a/shared/langs/en-us.php
+++ b/shared/langs/en-us.php
@@ -124,6 +124,7 @@ $s['chooseEditionDesc'] = 'Choose your desired edition';
 $s['allEditions'] = 'All editions';
 $s['selectEditionInfoText'] = 'Click the <i>Next</i> button to open the summary page of your selection.';
 $s['additionalEditionsInfo'] = 'If you need <b>additional editions</b> from the table on the right, select their <b>Required edition</b> above and proceed by clicking <i>Next</i>.<br>On the summary page select the <b>Create additional editions</b> option.';
+$s['showHiddenEditions'] = 'Show hidden editions (not recommended)';
 
 //download.php
 $s['summary'] = 'Summary';


### PR DESCRIPTION
A replacement of the current mechanism of deselecting PPIPro on the Select Edition page. This new approach allows to deselect and hide faulty editions (currently only PPIPro), making it less likely for an user to select them on accident.

Here is how it looks like with the changes on a random build of Windows 11:
![preview](https://user-images.githubusercontent.com/109633131/180486246-93bad9d5-ddfd-4e84-b038-17e359d4653a.png)

